### PR TITLE
feat! Added polling of ESPN api to dynamically refresh data

### DIFF
--- a/src/components/NFL/NFL.jsx
+++ b/src/components/NFL/NFL.jsx
@@ -41,7 +41,17 @@ const NFL = (props) => {
   const pick_submission_status = lateMsg ? 'error' : 'success';
 
   useEffect(() => {
-    get_user_fixtures(setFixtures, supabase);
+    const setupInterval = async () => {
+      const refresh_delay = await get_user_fixtures(setFixtures, supabase);
+
+      const intervalId = setInterval(() => {
+        get_user_fixtures(setFixtures, supabase);
+      }, refresh_delay);
+
+      return () => clearInterval(intervalId);
+    }
+
+    setupInterval();
   }, []);
 
   const cancel_picks = async () => {


### PR DESCRIPTION
This commit adds logic to poll ESPN API depending on what state the match is in. Furthermore, since I
was poking around in espn-api-parser anyway, I
cleaned it up and removed unnecessary duplication
of code.