### PR TITLE
feat! Use system timezone of user for UI

### DIFF
--- a/src/Utils/espn-api-parser.ts
+++ b/src/Utils/espn-api-parser.ts
@@ -19,11 +19,18 @@ const convert_minutes_to_ms = (minutes) => {
   return minutes * SECONDS_PER_MINUTE * MS_PER_SECOND;
 }
 
-const get_week_num = async () => {
+const get_curr_day_of_week = async () => {
+  const user_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const curr_day_of_week = (new Date()).toLocaleString("en-US", {
-    timezone: "America/Los_Angeles",
+    timeZone: user_timezone,
     weekday: 'long',
   });
+
+  return curr_day_of_week;
+}
+
+const get_week_num = async () => {
+  const curr_day_of_week = get_curr_day_of_week();
 
   // Create a new Date object to represent the current date and time
   const currentDate = new Date();
@@ -49,10 +56,7 @@ const get_week_num = async () => {
 }
 
 const get_fixtures = async () => {
-  const curr_day_of_week = (new Date()).toLocaleString("en-US", {
-    timezone: "America/Los_Angeles",
-    weekday: 'long',
-  });
+  const curr_day_of_week = get_curr_day_of_week();
 
   // Create a new Date object to represent the current date and time
   const currentDate = new Date();

--- a/src/components/Matchup/Matchup.jsx
+++ b/src/components/Matchup/Matchup.jsx
@@ -52,13 +52,29 @@ const Matchup = ({is_late_pick, players, match, match_index, fixtures, setFixtur
   const get_readable_kickoff_time = (kickoff_time) => {
     const date = new Date(kickoff_time);
 
+    const user_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const date_time_format = new Intl.DateTimeFormat('en', {
       dateStyle: 'full',
       timeStyle: 'short',
-      timeZone: 'America/Los_Angeles',
+      timeZone: user_timezone,
     });
 
-    return date_time_format.format(date) + ' PST';
+    const formatted_date = new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(date);
+
+    const formatted_time = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: 'numeric',
+      timeZone: user_timezone,
+      timeZoneName: 'short',
+    }).format(date);
+
+
+    return `${formatted_date} at ${formatted_time}`;
   };
 
   return (

--- a/src/components/NFL/NFL.jsx
+++ b/src/components/NFL/NFL.jsx
@@ -117,9 +117,11 @@ const NFL = (props) => {
 
   const is_late_pick = (kickoff_time) => {
     const kickoff_date = new Date(kickoff_time);
-    const timeZone = 'America/Los_Angeles';
-    const kickoff_day = new Intl.DateTimeFormat('en-US', { weekday: 'long', timeZone }).format(kickoff_date);
-    const curr_date_la = new Date(new Date().toLocaleString("en-US", {timeZone: timeZone}));
+    const user_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const kickoff_day = new Intl.DateTimeFormat('en-US', { weekday: 'long', user_timezone }).format(kickoff_date);
+    const curr_date_la = new Date(new Date().toLocaleString("en-US", {
+      timeZone: user_timezone,
+    }));
 
     const [SUNDAY, MONDAY, SATURDAY] = [0, 1, 6];
     const isolated_days = new Set(['Thursday', 'Friday']);
@@ -133,7 +135,9 @@ const NFL = (props) => {
     let earliest_combined_fixture_date = curr_date_la;
     for (const fixture of fixtures)
     {
-      const fixture_date_la = new Date(new Date(fixture.kickoff_time).toLocaleString("en-US", { timeZone: timeZone }));
+      const fixture_date_la = new Date(new Date(fixture.kickoff_time).toLocaleString("en-US", {
+        timeZone: user_timezone,
+      }));
 
       if (combined_days.has(fixture_date_la.getDay()) && fixture_date_la < earliest_combined_fixture_date)
       {


### PR DESCRIPTION
The user, wherever they are, will be forced to convert from PST to whichever timezone they reside in.

This hash introduces logic to use the system clock of the client.

issue: 21